### PR TITLE
Adding background cell color

### DIFF
--- a/rtflib/rtf.py
+++ b/rtflib/rtf.py
@@ -105,6 +105,20 @@ class Rtf(RtfElement):
         else:
             raise ValueError(f"element '{type(element).__name__}' incompatible with RTF")
 
+    def add_color(self, red: int , green: int , blue: int ):
+        if (
+            not [red, green, blue]
+            in self.colors
+        ):
+            self.colors.append(
+                [red, green, blue]
+            )
+            return len(self.colors)
+        else:
+            return self.colors.index(
+                    [red, green, blue]
+                    ) + 1
+    
     @property
     def rtf_code(self) -> str:
         code = "{\\rtf1\\ansi\\deff0\n"

--- a/rtflib/table.py
+++ b/rtflib/table.py
@@ -37,10 +37,11 @@ class Row(RtfElement):
     See: https://stackoverflow.com/questions/8349827/using-tables-in-rtf
     """
 
-    def __init__(self, *cells: RtfElement, ends: list[int] = None, borders: str = None, border_style: str="plain", padding: str = None, pad_size: int = 144):
+    def __init__(self, *cells: RtfElement, ends: list[int] = None, borders: str = None, border_style: str="plain",
+                 cell_bg=None, padding: str = None, pad_size: int = 144):
         self.cells = cells
         self.padding = ""
-        self.borders = borders
+        #self.borders = borders
 
         if ends:
             self.ends = ends
@@ -54,12 +55,18 @@ class Row(RtfElement):
             self.borders = [_compose_border(borders, border_style) for idx in range(len(self.cells))]
         else:
             self.borders = [""]*len(self.cells)
-
+        
+        if cell_bg:
+            self.cell_bg = [f"\\clcbpat{cell_bg}" for _ in range(len(self.cells))]
+        else:
+            self.cell_bg = [""]*len(self.cells)
+            
+    
     @property
     def rtf_code(self) -> str:
         rtfcode = f"\\trowd{self.padding}\n"
-        for end, cell, border in zip(self.ends, self.cells, self.borders):
-            rtfcode += f"{border}\\cellx{end}"
+        for end, border, bg in zip(self.ends, self.borders, self.cell_bg):
+            rtfcode += f"{border}{bg}\\cellx{end}"
         rtfcode += "\n"
         for cell in self.cells:
             rtfcode += "\\pard\\intbl{" + cell.rtf_code + "}\\cell\n"

--- a/rtflib/tests/table_widths_bgcolor.rtf
+++ b/rtflib/tests/table_widths_bgcolor.rtf
@@ -1,0 +1,55 @@
+{\rtf1\ansi\deff0
+\lndscpsxn\pgwsxn16838\pghsxn11906\marglsxn720\margrsxn720\margtsxn720\margbsxn720
+{
+\colortbl;
+\red255\green0\blue0;
+\red0\green255\blue0;
+\red254\green254\blue233;
+}
+hello world. A Line of text.\
+\ 
+\b \strike \fs16 hello world. A Line of text.\
+\ \b0 \strike0 \fs24 
+\cf1 hello world. A Red line\
+\ \cf0 \ 
+hello world. A mix of 
+\cf2 Green \cf0 \ 
+and 
+\cf1 Red\cf0 \ 
+ on a single line.\
+\ \
+\ 
+Here is a table with varying widths:
+\
+\trowd\trpaddl72\trpaddfl3\trpaddr72\trpaddfr3
+\clbrdrl\brdrs\clbrdrb\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\clcbpat3\cellx1500\clbrdrl\brdrs\clbrdrb\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\clcbpat3\cellx2100\clbrdrl\brdrs\clbrdrb\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\clcbpat3\cellx4500
+\pard\intbl{apple}\cell
+\pard\intbl{121}\cell
+\pard\intbl{selling}\cell
+\row
+\trowd\trpaddl72\trpaddfl3\trpaddr72\trpaddfr3
+\clbrdrl\brdrdot\clbrdrr\brdrdot\cellx1500\clbrdrl\brdrdot\clbrdrr\brdrdot\cellx2100\clbrdrl\brdrdot\clbrdrr\brdrdot\cellx4500
+\pard\intbl{linux}\cell
+\pard\intbl{136}\cell
+\pard\intbl{borrowing}\cell
+\row
+\trowd\trpaddl72\trpaddfl3\trpaddr72\trpaddfr3
+\clbrdrl\brdrdash\clbrdrr\brdrdash\clbrdrt\brdrdash\clbrdrb\brdrdash\clcbpat3\cellx1500\clbrdrl\brdrdash\clbrdrr\brdrdash\clbrdrt\brdrdash\clbrdrb\brdrdash\clcbpat3\cellx2100\clbrdrl\brdrdash\clbrdrr\brdrdash\clbrdrt\brdrdash\clbrdrb\brdrdash\clcbpat3\cellx4500
+\pard\intbl{banana}\cell
+\pard\intbl{142}\cell
+\pard\intbl{buying}\cell
+\row
+\trowd\trpaddl72\trpaddfl3\trpaddr72\trpaddfr3
+\clbrdrl\brdrs\clbrdrr\brdrs\cellx1500\clbrdrl\brdrs\clbrdrr\brdrs\cellx2100\clbrdrl\brdrs\clbrdrr\brdrs\cellx4500
+\pard\intbl{cherry}\cell
+\pard\intbl{137}\cell
+\pard\intbl{borrowing}\cell
+\row
+\trowd\trpaddl72\trpaddfl3\trpaddr72\trpaddfr3
+\clbrdrt\brdrdb\clcbpat3\cellx1500\clbrdrt\brdrdb\clcbpat3\cellx2100\clbrdrt\brdrdb\clcbpat3\cellx4500
+\pard\intbl{win2k}\cell
+\pard\intbl{147}\cell
+\pard\intbl{in debt}\cell
+\row
+
+}

--- a/rtflib/tests/test_rtflib.py
+++ b/rtflib/tests/test_rtflib.py
@@ -75,5 +75,38 @@ class TestRtflib(unittest.TestCase):
         with open(os.path.join(self.path, "table_widths_borders.rtf")) as fh:
             self.assertEqual(rtf.rtf_code.strip(), fh.read())
 
+    def test_table_borders(self):
+        rtf = Rtf()
+        page_orientation = RtfCode(PAGE_LAYOUTS["A4_landscape"])
+        rtf.preelements.append(page_orientation)
+        rtf.add(Line("hello world. A Line of text.\n"))
+        rtf.add(Line("hello world. A Line of text.\n", format=Format(bold=True,strike=True,size=16)))
+        rtf.add(Line("hello world. A Red line\n", color=Color(255, 0, 0)))
+        rtf.add(Line("hello world. A mix of "))
+        rtf.add(Line("Green ", color=Color(0, 255, 0)))
+        rtf.add(Line("and "))
+        rtf.add(Line("Red", color=Color(255, 0, 0)))
+        rtf.add(Line(" on a single line.\n\n"))
+        #
+        data = [['apple', 121, 'selling'], ['linux', 136, 'borrowing'],
+                ['banana', 142, 'buying'], ['cherry', 137, 'borrowing'],
+                ['win2k', 147, 'in debt']]
+        table_widths = [1500,2100,4500]
+        bg_cell_color = rtf.add_color(254,254,233)
+        row_borders = [["plain","lbrt"],["dot","lr"],["dash","lrtb"],["plain","lr"],["double","t"]]
+        rtf.add(Line("Here is a table with varying widths:"))
+        rows = []
+        for i,d in enumerate(data):
+            co,val,state = d
+            bstyle,border = row_borders[i]
+            cell_bg = bg_cell_color if i%2==0 else ""
+            row = Row(Line(co), Line(f"{val}"), Line(state), ends=table_widths,
+                      borders=border, border_style=bstyle, padding='lr', cell_bg=cell_bg, pad_size=72)
+            rows.append(row)
+        rtf.add(Table(*rows))
+        with open(os.path.join(self.path, "table_widths_bgcolor.rtf")) as fh:
+            self.assertEqual(rtf.rtf_code.strip(), fh.read())
+    
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
modified rtf.py to allow for add_color which returns index of the rgb for use on a row background

modified table to allow addition of bgtable color pattern.

also cleaned up my additions a little